### PR TITLE
Use HTTPS instead of SSH for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Easy3D"]
 	path = Easy3D
-	url = git@github.com:LiangliangNan/Easy3D.git
+	url = https://github.com/LiangliangNan/Easy3D.git


### PR DESCRIPTION
Hi, 

This PR lets LayerViz to be clone-able without a SSH key. (Some might not have SSH added to github)
Thanks
Martin